### PR TITLE
Added missing predict_end

### DIFF
--- a/mkdocs/docs/developer_guide.md
+++ b/mkdocs/docs/developer_guide.md
@@ -256,6 +256,9 @@ class MyContribution():
     def predict(self, *args, **kwargs):
 	# See: ludwig/predict.py and ludwig/cli.py
 
+    def predict_end(self, test_stats):
+        # See: ludwig/predict.py
+
     def test(self, *args, **kwargs):
 	# See: ludwig/test.py and ludwig/cli.py
 


### PR DESCRIPTION
I missed this injection point added by wandb

This won't be active until #514 is merged, but I think that is almost ready.
